### PR TITLE
RMET-1589 ::: Add new optional method to PlatformProtocol

### DIFF
--- a/OSCore.xcodeproj/xcshareddata/xcschemes/OSCore.xcscheme
+++ b/OSCore.xcodeproj/xcshareddata/xcschemes/OSCore.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D49B6F9A2720619600E0C354"
+               BuildableName = "OSCore.framework"
+               BlueprintName = "OSCore"
+               ReferencedContainer = "container:OSCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D49B6F9A2720619600E0C354"
+            BuildableName = "OSCore.framework"
+            BlueprintName = "OSCore"
+            ReferencedContainer = "container:OSCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OSCore/PlatformProtocol.swift
+++ b/OSCore/PlatformProtocol.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 public protocol PlatformProtocol {
-    
     func sendResult(result: String?, error: NSError?, callBackID:String)
     
+    // MARK: optional methods
+    func trigger(event: String, data: String)
+}
+
+/// Optional methods need to be implemented by default on the protocol's extension
+extension PlatformProtocol {
+    func trigger(event: String, data: String) {}
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,26 @@
+cd ..
+
+rm -rf build
+
+xcodebuild archive \
+-scheme OSCore \
+-configuration Release \
+-destination 'generic/platform=iOS Simulator' \
+-archivePath './scripts/build/OSCore.framework-iphonesimulator.xcarchive' \
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+
+
+xcodebuild archive \
+-scheme OSCore \
+-configuration Release \
+-destination 'generic/platform=iOS' \
+-archivePath './scripts/build/OSCore.framework-iphoneos.xcarchive' \
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+
+
+xcodebuild -create-xcframework \
+-framework './scripts/build/OSCore.framework-iphonesimulator.xcarchive/Products/Library/Frameworks/OSCore.framework' \
+-framework './scripts/build/OSCore.framework-iphoneos.xcarchive/Products/Library/Frameworks/OSCore.framework' \
+-output './scripts/build/OSCore.xcframework'


### PR DESCRIPTION
## Description
- Add a new method that triggers events with the passed data. This method is optional, so a default empty implementation is provided.
- Add a scheme and a build script to OSCore. This way it is structured as other iOS libs.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1589

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [X] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [X] iOS
- [ ] JavaScript

## Checklist
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
